### PR TITLE
Fix "Edit on Github" URLs

### DIFF
--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -25,7 +25,7 @@ jobs:
         pip install git+https://github.com/vircadia/video.git
         pip install -U Sphinx==2.4.4
         pip install --upgrade recommonmark
-        pip install sphinx_rtd_theme
+        pip install sphinx_rtd_theme==0.4.3
     - name: Build documentation
       shell: bash
       run: |
@@ -69,7 +69,7 @@ jobs:
         pip install git+https://github.com/vircadia/video.git
         pip install -U Sphinx==2.4.4
         pip install --upgrade recommonmark
-        pip install sphinx_rtd_theme
+        pip install sphinx_rtd_theme==0.4.3
     - name: Build german documentation
       shell: bash
       run: |

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -24,7 +24,7 @@ jobs:
         pip install git+https://github.com/vircadia/video.git
         pip install -U Sphinx==2.4.4
         pip install --upgrade recommonmark
-        pip install sphinx_rtd_theme
+        pip install sphinx_rtd_theme==0.4.3
     - name: Build documentation
       shell: bash
       run: |

--- a/MAINTAINER_INFO.md
+++ b/MAINTAINER_INFO.md
@@ -132,7 +132,7 @@ python3 -m pip install --upgrade pip
 python3 -m pip install git+https://github.com/vircadia/video.git
 python3 -m pip install -U Sphinx==2.4.4
 python3 -m pip install --upgrade recommonmark
-python3 -m pip install sphinx_rtd_theme
+python3 -m pip install sphinx_rtd_theme==0.4.3
 python3 -m pip install sphinx-intl
 ```
 Git hooks log file is located at `/var/lib/docker/volumes/weblate-docker_weblate-data/_data/vcs/vircadia-documentation/contribute/.git/git_hook_output.log`

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ We encourage you to compile the documentation locally on your computer prior to 
 7. Install our Sphinx theme:
 
     ```
-    C:\> pip install sphinx_rtd_theme
+    C:\> pip install sphinx_rtd_theme==0.4.3
     ```
 
 ## Compile Vircadia Documentation Locally


### PR DESCRIPTION
Fixes #114 by changing sphinx_rtd_theme to old stable version 0.4.3.
They fixed the theme not using a configuration parameter which doesn't exist in our repo, probably because we are so far behind upstream. https://github.com/readthedocs/sphinx_rtd_theme/pull/1010
There isn't really anything that can go wrong here as we have been using 0.4.3 for the longest time.