### PR TITLE
Replace recommonmark with myst-parser

### DIFF
--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -24,7 +24,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install git+https://github.com/vircadia/video.git
         pip install -U Sphinx==2.4.4
-        pip install --upgrade recommonmark
+        pip install --upgrade myst-parser
         pip install sphinx_rtd_theme
     - name: Build documentation
       shell: bash
@@ -68,7 +68,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install git+https://github.com/vircadia/video.git
         pip install -U Sphinx==2.4.4
-        pip install --upgrade recommonmark
+        pip install --upgrade myst-parser
         pip install sphinx_rtd_theme
     - name: Build german documentation
       shell: bash
@@ -154,7 +154,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install git+https://github.com/vircadia/video.git
         pip install -U Sphinx==2.4.4
-        pip install --upgrade recommonmark
+        pip install --upgrade myst-parser
         pip install sphinx_rtd_theme
     - name: Check source documentation
       shell: bash

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -23,7 +23,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install git+https://github.com/vircadia/video.git
         pip install -U Sphinx==2.4.4
-        pip install --upgrade recommonmark
+        pip install --upgrade myst-parser
         pip install sphinx_rtd_theme
     - name: Build documentation
       shell: bash

--- a/MAINTAINER_INFO.md
+++ b/MAINTAINER_INFO.md
@@ -119,6 +119,8 @@ date
 cd docs
 make gettext
 sphinx-intl update -l de
+sphinx-intl update -l es
+sphinx-intl update -l fr
 sphinx-intl update -l jp
 git commit -a -m "Update translation files"
 ) |& tee .git/git_hook_output.log

--- a/MAINTAINER_INFO.md
+++ b/MAINTAINER_INFO.md
@@ -131,7 +131,7 @@ su weblate
 python3 -m pip install --upgrade pip
 python3 -m pip install git+https://github.com/vircadia/video.git
 python3 -m pip install -U Sphinx==2.4.4
-python3 -m pip install --upgrade recommonmark
+python3 -m pip install --upgrade myst-parser
 python3 -m pip install sphinx_rtd_theme
 python3 -m pip install sphinx-intl
 ```

--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ We encourage you to compile the documentation locally on your computer prior to 
     C:\> pip install sphinx
     ```
 
-6. Install the Markdown parser recommonmark:
+6. Install the Markdown parser MyST-Parser:
 
     ```
-    C:\> pip install --upgrade recommonmark
+    C:\> pip install --upgrade myst-parser
     ```
 
 7. Install our Sphinx theme:
@@ -89,6 +89,7 @@ Replace `xX` with your [language code](https://www.sphinx-doc.org/en/master/usag
 
 Most of our docs use RST. reStructuredText (RST) is the default plaintext markup language used by Sphinx. It is an extensible markup language, that is fully customizable. To learn more, refer to Sphinx's [reStructuredText Primer](https://www.sphinx-doc.org/en/2.0/usage/restructuredtext/basics.html).
 RST should be used for any real documentation, as Markdown only supports very basic directives.
+The MyST parser expands Markdown significantly, but RST should still be preferred as writers and translators would need to learn two big markup languages instead of just one.
 A valuable resource for RST is the [official documentation](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html).
 
 ## Using videos

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,7 +39,7 @@ needs_sphinx = '2.4.4'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'recommonmark', 'sphinxcontrib.video'
+    'myst_parser', 'sphinxcontrib.video'
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
This replaces the recommonmark markdown parser with myst-parser.
recommonmark is badly supported and will likely be deprecated at the end of this month.

Fixes #128 
While it does fix links being parsed incorrectly for translation, the new strings will still contain the wrong translation and only be marked as "fuzzy" indicating that the translation needs to be updated. Translation tools like Weblate will see this fuzzy indicator and mark the translation as outdated and needing attention.

Another concern is that the switch to myst-parser adds 108 new warnings. These warnings are all of the same type and are all valid.
Example:
```
docs/source/release-notes/2021-1-1-Eos.md:9: WARNING: Non-consecutive header level increase; 2 to 4 [myst.header]
```
The warning indicated that the level 2 heading  (In this example `## Interface (Codename Athena)`) is followed by a level 2 heading (In this example `#### General`). To do this doesn't really make any sense and may break browser accessibility tools.
Recommonmark didn't throw a warning, but also didn't abide to the specified levels. In this example it just parsed the level 4 `#### General` heading as a level 3 heading. GitHub on the other hand does exactly what we say and parses it as a level 4 heading.
I assume this was done from a design perspective. Personally I like the smaller section headers more, but that should be changed in the theme and not by resorting to potentially incompatible/illegal behaviour in every markdown file.

A preview is available here: https://data.moto9000.moe/sphinx/PR136/ ( 2d37f9a )
The dependency has been installed on Weblate, so it will be able to immediately update the translation files.