### PR TITLE
Fix urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For Vircadia's main documentation system, we use **Sphinx** to generate it, and 
 * Index and Glossary support
 * Localization support
 
-Our main documentation is hosted at https://docs.vircadia.dev.
+Our main documentation is hosted at https://docs.vircadia.com.
 
 ## Translate
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -42,6 +42,7 @@ help:
 		@sed -i "s*(cmake/modules/)*(https://github.com/vircadia/vircadia/tree/master/cmake/modules)*g" "$(BUILDGENERAL)"
 		@sed -i "s*(interface/external)*(https://github.com/vircadia/vircadia/tree/master/interface/external)*g" "$(BUILDGENERAL)"
 		@sed -i "s*(BUILD.md)*(../build/BUILD.md)*g" "$(INSTALLER)"
+		@sed -i "s*(BUILD_OSX.md)*(../build/BUILD_OSX.md)*g" "$(INSTALLER)"
 		@echo "done"
 	@echo "\nHanding over to sphinx-build."
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/source/_static/resources/material-entity/CastleWall.hfm.json
+++ b/docs/source/_static/resources/material-entity/CastleWall.hfm.json
@@ -5,9 +5,9 @@
       "name": "CastleWall",
       "model": "hifi_pbr",
       "albedo": [1, 1, 1],
-      "albedoMap": "https://docs.vircadia.dev/_static/resources/material-entity/CastleWall_Base_Color.png",
-      "roughnessMap": "https://docs.vircadia.dev/_static/resources/material-entity/CastleWall_Roughness.png",
-      "normalMap": "https://docs.vircadia.dev/_static/resources/material-entity/CastleWall_Normal.png"
+      "albedoMap": "https://docs.vircadia.com/_static/resources/material-entity/CastleWall_Base_Color.png",
+      "roughnessMap": "https://docs.vircadia.com/_static/resources/material-entity/CastleWall_Roughness.png",
+      "normalMap": "https://docs.vircadia.com/_static/resources/material-entity/CastleWall_Normal.png"
     }
   ]
 }

--- a/docs/source/_templates/versions.html
+++ b/docs/source/_templates/versions.html
@@ -9,11 +9,11 @@
       <dl>
         <dt>{{ _('Languages') }}</dt>
         <dd>
-            <a href="https://docs.vircadia.dev/">en</a>
-            <a href="https://docs.vircadia.dev/de/">de</a>
-            <a href="https://docs.vircadia.dev/es/">es</a>
-            <a href="https://docs.vircadia.dev/fr/">fr</a>
-            <a href="https://docs.vircadia.dev/jp/">jp</a>
+            <a href="https://docs.vircadia.com/">en</a>
+            <a href="https://docs.vircadia.com/de/">de</a>
+            <a href="https://docs.vircadia.com/es/">es</a>
+            <a href="https://docs.vircadia.com/fr/">fr</a>
+            <a href="https://docs.vircadia.com/jp/">jp</a>
         </dd>
       </dl>
 <!--

--- a/docs/source/create/entities/material-entity.rst
+++ b/docs/source/create/entities/material-entity.rst
@@ -17,7 +17,7 @@ To add a material to your object in Vircadia, you need to specify the material d
 
 .. note:: We are aware of the difficulties involved in converting your material data to a JSON file and are working on making the process easier for our users. In the meantime, we recommend embedding your material data in your models as FBX or glTF files if you are facing difficulties generating a JSON file.
 
-This is what the JSON file for a sample `castle wall material <https://docs.vircadia.dev/_static/resources/material-entity/CastleWall.hfm.json>`_ looks like:
+This is what the JSON file for a sample `castle wall material <https://docs.vircadia.com/_static/resources/material-entity/CastleWall.hfm.json>`_ looks like:
 
 .. code-block:: json
 
@@ -28,9 +28,9 @@ This is what the JSON file for a sample `castle wall material <https://docs.virc
          "name": "CastleWall",
          "model": "hifi_pbr",
          "albedo": [1, 1, 1],
-         "albedoMap": "https://docs.vircadia.dev/_static/resources/material-entity/CastleWall_Base_Color.png",
-         "roughnessMap": "https://docs.vircadia.dev/_static/resources/material-entity/CastleWall_Roughness.png",
-         "normalMap": "https://docs.vircadia.dev/_static/resources/material-entity/CastleWall_Normal.png"
+         "albedoMap": "https://docs.vircadia.com/_static/resources/material-entity/CastleWall_Base_Color.png",
+         "roughnessMap": "https://docs.vircadia.com/_static/resources/material-entity/CastleWall_Roughness.png",
+         "normalMap": "https://docs.vircadia.com/_static/resources/material-entity/CastleWall_Normal.png"
       }
    ]
    }
@@ -48,7 +48,7 @@ _________________________________
 
 .. note:: At this time, we have no way to automatically generate a JSON file with another tool, and you will need to write your own JSON file.
 
-Once you have your material entity JSON file, you can add it to an object in Vircadia. Let's add the `castle wall material <https://docs.vircadia.dev/_static/resources/material-entity/CastleWall.hfm.json>`_ to a box entity in your domain.
+Once you have your material entity JSON file, you can add it to an object in Vircadia. Let's add the `castle wall material <https://docs.vircadia.com/_static/resources/material-entity/CastleWall.hfm.json>`_ to a box entity in your domain.
 
 1. In Interface, pull up your HUD or Tablet and go to **Create**.
 2. Create a wall. Click the 'Cube' icon to add a box entity and change the dimensions to make it resemble a wall.
@@ -85,9 +85,9 @@ To add a material entity directly into the **Create** Tools app:
          "name": "CastleWall",
          "model": "hifi_pbr",
          "albedo": [1, 1, 1],
-         "albedoMap": "https://docs.vircadia.dev/_static/resources/material-entity/CastleWall_Base_Color.png",
-         "roughnessMap": "https://docs.vircadia.dev/_static/resources/material-entity/CastleWall_Roughness.png",
-         "normalMap": "https://docs.vircadia.dev/_static/resources/material-entity/CastleWall_Normal.png"
+         "albedoMap": "https://docs.vircadia.com/_static/resources/material-entity/CastleWall_Base_Color.png",
+         "roughnessMap": "https://docs.vircadia.com/_static/resources/material-entity/CastleWall_Roughness.png",
+         "normalMap": "https://docs.vircadia.com/_static/resources/material-entity/CastleWall_Normal.png"
       }
    ]
    }

--- a/docs/source/create/entities/open-tablet-page-tutorial.rst
+++ b/docs/source/create/entities/open-tablet-page-tutorial.rst
@@ -46,7 +46,7 @@ The entity you create for your button has to be `triggerable <entity-behavior.ht
   {
     "useConfirmDialog": true,
     "confirmDialogMessage": "Are you sure you want to open this link?",
-    "url": "https://docs.vircadia.dev/",
+    "url": "https://docs.vircadia.com/",
     // options are "interface" and "browser"
     // "interface" opens an overlay, "browser" opens the OS' external browser.
     "openIn": "interface",

--- a/docs/source/create/entities/primitive-painting-set-tutorial.md
+++ b/docs/source/create/entities/primitive-painting-set-tutorial.md
@@ -30,7 +30,7 @@ Our painting set comprises three elements:
 All of the logic for our painting set is contained in the brush head. The rest of the content is made by parenting entities to one another to make our brush, palette, and canvas.
 
 ### Create a Paint Brush
-We'll start by creating the paint brush. The brush is comprised of two parts, the handle and the brush head. The brush handle is the parent of the brush head, so we can control the movement and color of the brush head using only the handle. 
+We'll start by creating the paint brush. The brush is comprised of two parts, the handle and the brush head. The brush handle is the parent of the brush head, so we can control the movement and color of the brush head using only the handle.
 
 To create the brush handle:
 1. In Interface, pull up your HUD or Tablet and go to **Create**.
@@ -47,7 +47,7 @@ To create the brush head:
 4. Name your entity 'Paint-Paintbrush-Head' by selecting the text box at the top of the 'Properties' tab.
 5. Scroll down to the 'Spatial' section. Change the local dimensions to {x: 0.05, y: 0.1, z: 0.05}.
 
-Once you've created the brush head, you can parent the brush handle to it: 
+Once you've created the brush head, you can parent the brush handle to it:
 
 1. In **Create** Tools app, select your brush handle and go to the 'Properties' tab.
 2. Copy the 'entityID'.
@@ -88,7 +88,7 @@ Repeat the above steps to create additional paint colors for your palette.
 The last component that makes up our painting set is the canvas we'll use for our "pixel" style painting. We've provided a JSON file for you to import a canvas so you don't need to go through each step individually, but you can import the grid multiple times to make a larger painting space, if desired.
 
 1. In Interface, go to **Menu > Edit** and select 'Import Entities from URL'.
-2. Paste [this URL](https://docs.vircadia.dev/_static/resources/entities/canvas.json) into the dialog window and select 'OK'.
+2. Paste [this URL](https://docs.vircadia.com/_static/resources/entities/canvas.json) into the dialog window and select 'OK'.
 
 The canvas is made up of box entities parented to a single backplate, but you could use any entities to create a scene that could be painted this way.
 
@@ -104,7 +104,7 @@ To add the paint brush script:
 1. In Interface, pull up your HUD or Tablet and go to **Create**.
 2. Select the Paint-Brush-Head entity.
 3. Go to the 'Properties' tab and scroll down to 'Behavior'.
-4. Next to 'Script', paste the script URL. In this case, it is '[brushScript.js](https://docs.vircadia.dev/_static/resources/entities/brushScript.js)'.
+4. Next to 'Script', paste the script URL. In this case, it is '[brushScript.js](https://docs.vircadia.com/_static/resources/entities/brushScript.js)'.
 5. After you close the **Create** app, test it out by painting on the canvas in your domain!
 
 **See Also**

--- a/docs/source/create/materials/procedural-shaders.rst
+++ b/docs/source/create/materials/procedural-shaders.rst
@@ -50,7 +50,7 @@ Shaders' code is stored as a file. Fragment shaders will typically have the file
 
 Shaders are applied to entities and avatars by way of attaching them to a material. That material is then attached to your entity or avatar, therefore applying the shader as intended.
 
-If you are unfamiliar with material entities, you can find more information `here <https://docs.vircadia.dev/create/entities/material-entity.html>`_.
+If you are unfamiliar with material entities, you can find more information :doc:`here <../entities/material-entity>`.
 
 Material entities have data that is stored in the JSON format, and they have a property called ``materialData``. The ``materialData`` property requires ``model`` and ``procedural`` fields. Here is an example::
 
@@ -59,7 +59,7 @@ Material entities have data that is stored in the JSON format, and they have a p
             "model": "hifi_shader_simple",
             "procedural": {
                 "version": 3,
-                "shaderUrl": "https://docs.vircadia.dev/_static/resources/Proceduralv3.fs"
+                "shaderUrl": "https://docs.vircadia.com/_static/resources/Proceduralv3.fs"
             }
         }]
     }
@@ -75,7 +75,7 @@ The ``materialData`` JSON can be applied either via the Vircadia Interface’s e
     			"model": "hifi_shader_simple",
     			"procedural": {
     			  	"version": 3,
-    			  	"shaderUrl": "https://docs.vircadia.dev/_static/resources/Proceduralv3.fs"
+    			  	"shaderUrl": "https://docs.vircadia.com/_static/resources/Proceduralv3.fs"
     			}
     		}
     	})
@@ -98,7 +98,7 @@ A shader consists of two primary pieces: **the main function** that is responsib
 A basic template for a shader without helper functions looks something like this example::
 
     // Helper functions go here.
-    
+
     // version 3
     float getProceduralFragment(inout ProceduralFragment data) {
         data.diffuse = vec3(0);
@@ -342,7 +342,7 @@ Procedural materials also support up to 4 custom textures and many custom unifor
     		"model": "hifi_shader_simple",
     		"procedural": {
     		    "version": 3,
-    		    "shaderUrl": "https://docs.vircadia.dev/_static/resources/Proceduralv3.fs",
+    		    "shaderUrl": "https://docs.vircadia.com/_static/resources/Proceduralv3.fs",
     		    "uniforms": {
     		        "_diffuse": [1, 0, 0],
     		        "_alpha": 1.0,

--- a/docs/source/developer/installer/INSTALLER.md
+++ b/docs/source/developer/installer/INSTALLER.md
@@ -87,7 +87,7 @@ For code signing to work, you will need to set the `HF_PFX_FILE` and `HF_PFX_PAS
 
 ### MacOS
 
-1. Ensure you have all the prerequisites fulfilled from the [MacOS Build Guide](BUILD_OSX.md).
+1. Ensure you have all the prerequisites fulfilled from the [MacOS Build Guide](../build/BUILD_OSX.md).
 2. Perform a clean CMake in your build folder. e.g.
     ```bash
     BUILD_GLOBAL_SERVICES=STABLE USE_STABLE_GLOBAL_SERVICES=1 RELEASE_BUILD=PRODUCTION BUILD_NUMBER="Insert Build Identifier here e.g. short hash of your last Git commit" RELEASE_NAME="Insert Release Name Here" STABLE_BUILD=1 PRODUCTION_BUILD=1 RELEASE_NUMBER="Insert Release Version Here e.g. 1.1.0" RELEASE_TYPE=PRODUCTION cmake -DCMAKE_OSX_SYSROOT="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk" -DCLIENT_ONLY=1 -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DOSX_SDK=10.12  ..

--- a/docs/source/home.rst
+++ b/docs/source/home.rst
@@ -32,14 +32,14 @@ In addition to the documentation, you can join the discussion on the Vircadia `D
               :target: https://discordapp.com/invite/Pvx2vke
 
 
-This documentation is authored in `English <https://docs.vircadia.dev/>`_.
+This documentation is authored in `English <https://docs.vircadia.com/>`_.
 
 The following translations are available:
 
-* `Deutsch <https://docs.vircadia.dev/de/>`_ |de_trans|
-* `Español <https://docs.vircadia.dev/es/>`_ |es_trans|
-* `Français <https://docs.vircadia.dev/fr/>`_ |fr_trans|
-* `日本語 <https://docs.vircadia.dev/jp/>`_ |jp_trans|
+* `Deutsch <https://docs.vircadia.com/de/>`_ |de_trans|
+* `Español <https://docs.vircadia.com/es/>`_ |es_trans|
+* `Français <https://docs.vircadia.com/fr/>`_ |fr_trans|
+* `日本語 <https://docs.vircadia.com/jp/>`_ |jp_trans|
 
 .. |de_trans| image:: https://weblate.vircadia.dev/widgets/vircadia-documentation/de/svg-badge.svg
               :class: inline

--- a/docs/source/host/maintain-domain/update-software.rst
+++ b/docs/source/host/maintain-domain/update-software.rst
@@ -2,7 +2,7 @@
 Update to the Latest Version
 ############################
 
-Vircadia is always changing, as we work to improve performance and add features that will enhance your experience in the metaverse. If a new version has been released, all of our users will be prompted to update to the latest (and most stable) release. 
+Vircadia is always changing, as we work to improve performance and add features that will enhance your experience in the metaverse. If a new version has been released, all of our users will be prompted to update to the latest (and most stable) release.
 
 .. contents:: On This Page
     :depth: 2
@@ -11,10 +11,10 @@ Vircadia is always changing, as we work to improve performance and add features 
 Protocol Compatibility
 -----------------------------------------
 
-Vircadia requires that the client and server (the visitor's installed software and the server's software) maintain protocol compatibility across versions. Some of our releases include protocol changes, and will affect the visitors who can visit your domain. 
+Vircadia requires that the client and server (the visitor's installed software and the server's software) maintain protocol compatibility across versions. Some of our releases include protocol changes, and will affect the visitors who can visit your domain.
 
 * An updated client version will be unable to connect to a domain that is not updated.
-* A client running an older version will be unable to connect to a domain that is running a new version. 
+* A client running an older version will be unable to connect to a domain that is running a new version.
 
 Both of these will result in an error message "Protocol Mismatch".
 
@@ -24,7 +24,7 @@ Upgrade Your Domain Server
 
 Because all of Vircadia's users are encouraged to update to the latest release, it is highly likely that the majority of your visitors are running the newest version of Vircadia. Therefore, if there has been a protocol change (check the :doc:`Release Notes <../../release-notes>` for your version), we strongly recommend that you upgrade your domain server to the newest release.
 
-To update a local server on Windows: 
+To update a local server on Windows:
 
 1. Download the latest `Client + Sandbox installer <https://vircadia.com/download-vircadia/#server>`_ from Vircadia's website or download the upgrade when prompted to on your server.
 2. On your local server, quit Sandbox:
@@ -33,10 +33,10 @@ To update a local server on Windows:
 
 3. Run the installer.
 
-After installation, check your local server's domain settings to ensure that its running the most recent version. 
+After installation, check your local server's domain settings to ensure that its running the most recent version.
 
 To update a server on Linux:
 
-1. Run the very same commands that you had used to install your server `here <https://docs.vircadia.dev/host/server-setup/linux-server.html#installation>`_.
+1. Run the very same commands that you had used to install your server `here <https://docs.vircadia.com/host/server-setup/linux-server.html#installation>`_.
 
-After installation, check your server's domain settings to ensure that its running the most recent version. 
+After installation, check your server's domain settings to ensure that its running the most recent version.

--- a/docs/source/release-notes/v86-k2.md
+++ b/docs/source/release-notes/v86-k2.md
@@ -70,7 +70,7 @@ The numbers at the end of each item are the PR numbers in the Vircadia [GitHub r
 
 The numbers at the end of each item are the PR numbers in the Vircadia-Docs-Sphinx [GitHub repo](https://github.com/vircadia/vircadia-docs-sphinx).
 
-* Added initial shader documentation that can be found under Create > Materials, or [here](https://docs.vircadia.dev/create/materials/procedural-shaders.html). (#17)
+* Added initial shader documentation that can be found under Create > Materials, or [here](https://docs.vircadia.com/create/materials/procedural-shaders.html). (#17)
 * Various other updates and fixes to the main documentation. (#1, #2, #3, #4, #5, #9, #10, #12)
 
 ### API Docs


### PR DESCRIPTION
This PR fixes all URLs broken by the docs.vircadia.dev -> docs.vircadia.com change.

It also contains a small change for installer.md that fixes a URL and gets rid of a warning.