### PR TITLE
Bump Sphinx version to keep compatability with upstream myst-parser

### DIFF
--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install git+https://github.com/vircadia/video.git
-        pip install -U Sphinx==2.4.4
+        pip install -U Sphinx==3.5.4
         pip install --upgrade myst-parser
         pip install sphinx_rtd_theme
     - name: Build documentation
@@ -65,7 +65,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install git+https://github.com/vircadia/video.git
-        pip install -U Sphinx==2.4.4
+        pip install -U Sphinx==3.5.4
         pip install --upgrade myst-parser
         pip install sphinx_rtd_theme
     - name: Build german documentation

--- a/.github/workflows/master_warnings.yml
+++ b/.github/workflows/master_warnings.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install git+https://github.com/vircadia/video.git
-        pip install -U Sphinx==2.4.4
+        pip install -U Sphinx==3.5.4
         pip install --upgrade myst-parser
         pip install sphinx_rtd_theme
     - name: Check source documentation

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install git+https://github.com/vircadia/video.git
-        pip install -U Sphinx==2.4.4
+        pip install -U Sphinx==3.5.4
         pip install --upgrade myst-parser
         pip install sphinx_rtd_theme
     - name: Build documentation

--- a/MAINTAINER_INFO.md
+++ b/MAINTAINER_INFO.md
@@ -132,7 +132,7 @@ docker-compose exec --user root weblate bash
 apt install make gettext
 python3 -m pip install --upgrade pip
 python3 -m pip install git+https://github.com/vircadia/video.git
-python3 -m pip install -U Sphinx==2.4.4
+python3 -m pip install -U Sphinx==3.5.4
 python3 -m pip install --upgrade myst-parser
 python3 -m pip install sphinx_rtd_theme
 python3 -m pip install sphinx-intl

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ We encourage you to compile the documentation locally on your computer prior to 
     C:\> pip install git+https://github.com/vircadia/video.git
     ```
 
-5. Install Sphinx version >=2.4.4 in a command line:
+5. Install Sphinx version 3.x.x in a command line:
 
     ```
-    C:\> pip install sphinx
+    C:\> pip install -U Sphinx==3.5.4
     ```
 
 6. Install the Markdown parser MyST-Parser:


### PR DESCRIPTION
The newest stable release of myst-parser requires Sphinx 3 or 4. Because of this, our Sphinx was upgraded from 2.4.4 to latest which is 4.0.2 which doesn't work yet with out theme.
Sphinx 3 has been working fine on our docs for some time now, so it seems like it's time to finally upgrade to it.

This fixes the search function being broken on docs.vircadia.com