### PR TITLE
Add link health checker to GitHub Actions.

### DIFF
--- a/.github/workflows/master_linkcheck.yml
+++ b/.github/workflows/master_linkcheck.yml
@@ -1,0 +1,33 @@
+name: Master CI Check Links
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  check_links:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: [3.7]
+
+    name: Check for broken links
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install git+https://github.com/vircadia/video.git
+        pip install -U Sphinx==3.5.4
+        pip install --upgrade myst-parser
+        pip install sphinx_rtd_theme
+    - name: Check links in documentation
+      shell: bash
+      run: |
+        cd docs
+        make SPHINXOPTS="-W --keep-going" linkcheck

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Status
 
-![Master CI Deploy](https://github.com/vircadia/vircadia-docs-sphinx/actions/workflows/master_build.yml/badge.svg) ![Master CI Warnings](https://github.com/vircadia/vircadia-docs-sphinx/actions/workflows/master_warnings.yml/badge.svg)
+![Master CI Deploy](https://github.com/vircadia/vircadia-docs-sphinx/actions/workflows/master_build.yml/badge.svg) ![Master CI Warnings](https://github.com/vircadia/vircadia-docs-sphinx/actions/workflows/master_warnings.yml/badge.svg) ![Master CI Linkcheck](https://github.com/vircadia/vircadia-docs-sphinx/actions/workflows/master_linkcheck.yml/badge.svg)
 
 # Overview of Vircadia's Documentation Tools
 


### PR DESCRIPTION
This PR adds linkcheck to our run tests.
Since this takes a couple of minutes and queries a lot of URLs, this should only be added to master builds.