### PR TITLE
Add python module to avoid sphinx-intl error.

### DIFF
--- a/.github/workflows/update_translation_files.yml
+++ b/.github/workflows/update_translation_files.yml
@@ -31,6 +31,7 @@ jobs:
         pip install 'myst-parser==0.16.0'
         pip install  attr
         pip install attrs
+        pip install sphinx-intl
     - name: Regenerate translation files
       shell: bash
       run: |


### PR DESCRIPTION
I was able to avoid the "Build and deploy english docs" and "Build and deploy translated docs" errors.
However, the error occurred on the next CI job.
I have added the install command for the missing module and hope you will consider merging and updating the yml file.